### PR TITLE
Add empty-board guidance to PROCESS.md

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -49,3 +49,10 @@ To prevent deadlocks:
 ## 7. Merging
 - If **Author** and received **Approval**:
   - `gh pr merge --squash --delete-branch`
+
+## 8. Empty Board
+When no issues are open and no PRs need review:
+
+1.  **Scan**: Review the codebase for potential improvements (bugs, missing tests, stale docs, unclear wording).
+2.  **File**: Create a GitHub issue for each improvement found. Do not start work without an issue.
+3.  **Yield**: If no improvements are found, exit. Do not invent work.


### PR DESCRIPTION
## Summary
- Adds Section 8 ("Empty Board") to PROCESS.md with guidance for when no issues or PRs need attention
- Agents should scan for improvements and file issues, or yield if nothing found
- Prevents unsolicited work by requiring an issue before starting

Closes #2

[Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)