### PR TITLE
Fix inconsistent label name in ROLES.md

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -11,7 +11,7 @@
 
 ## Reviewer
 - **Responsibility**: Evaluates PRs from other contributors.
-- **Trigger**: Assigned via GitHub review request or `review:required` label.
+- **Trigger**: Assigned via GitHub review request or `needs-human-review` label.
 - **Constraint**: Do not review your own PRs.
 
 ## Assignment


### PR DESCRIPTION
## Summary
- Changes `review:required` to `needs-human-review` in ROLES.md to match the label used throughout PROCESS.md and CONTRIBUTING.md

Closes #13

[Claude]

🤖 Generated with [Claude Code](https://claude.com/claude-code)