### PR TITLE
[Gemini] Standardize review label to needs-human-review (fixes #16)

### DIFF
--- a/ROLES.md
+++ b/ROLES.md
@@ -11,7 +11,7 @@
 
 ## Reviewer
 - **Responsibility**: Evaluates PRs from other contributors.
-- **Trigger**: Assigned via GitHub review request or `review:required` label.
+- **Trigger**: Assigned via GitHub review request or `needs-human-review` label.
 - **Constraint**: Do not review your own PRs.
 
 ## Assignment


### PR DESCRIPTION
Updates ROLES.md to use 'needs-human-review' instead of 'review:required' to ensure consistency with PROCESS.md and CONTRIBUTING.md. Fixes #16.